### PR TITLE
Two dead-simple implementations in Ruby

### DIFF
--- a/ruby-celluloid-io/Gemfile
+++ b/ruby-celluloid-io/Gemfile
@@ -1,0 +1,4 @@
+source 'http://rubygems.org'
+ruby "1.9.3"
+
+gem 'celluloid-io'

--- a/ruby-celluloid-io/Gemfile.lock
+++ b/ruby-celluloid-io/Gemfile.lock
@@ -1,0 +1,18 @@
+GEM
+  remote: http://rubygems.org/
+  specs:
+    celluloid (0.12.4)
+      facter (>= 1.6.12)
+      timers (>= 1.0.0)
+    celluloid-io (0.12.1)
+      celluloid (~> 0.12.0)
+      nio4r (>= 0.4.0)
+    facter (1.6.17)
+    nio4r (0.4.3)
+    timers (1.1.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  celluloid-io

--- a/ruby-celluloid-io/server.rb
+++ b/ruby-celluloid-io/server.rb
@@ -1,0 +1,25 @@
+require 'celluloid/io'
+
+class EchoServer
+  include Celluloid::IO
+
+  def initialize(host, port)
+    @server = TCPServer.new(host, port)
+    run
+  end
+
+  def finalize
+    @server.close if @server
+  end
+
+  def run
+    loop { handle_connection! @server.accept }
+  end
+
+  def handle_connection(socket)
+    loop { socket.write socket.readpartial(1024) }
+  rescue EOFError
+  end
+end
+
+EchoServer.new('127.0.0.1', 9000)

--- a/ruby-eventmachine/Gemfile
+++ b/ruby-eventmachine/Gemfile
@@ -1,0 +1,4 @@
+source 'http://rubygems.org'
+ruby "1.9.3"
+
+gem 'eventmachine'

--- a/ruby-eventmachine/Gemfile.lock
+++ b/ruby-eventmachine/Gemfile.lock
@@ -1,0 +1,10 @@
+GEM
+  remote: http://rubygems.org/
+  specs:
+    eventmachine (1.0.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  eventmachine

--- a/ruby-eventmachine/server.rb
+++ b/ruby-eventmachine/server.rb
@@ -1,0 +1,15 @@
+#!/usr/bin/env ruby
+
+require 'rubygems'
+require 'eventmachine'
+
+module EchoServer
+  def receive_data data
+    send_data data
+  end
+end
+
+EventMachine::run {
+  EventMachine::start_server "127.0.0.1", 9000, EchoServer
+  puts 'running echo server on port 9000'
+}


### PR DESCRIPTION
Client compilation warning:
make
c++ -Os -march=native -mtune=native -std=c++0x -Wall -I/opt/local/include -L/opt/local/lib -lboost_thread-mt -lboost_system-mt -pthread  client.cc   -o client
ld: warning: directory not found for option '-L/opt/local/lib'

Client failure:
Starting tests
Chld: 0 ConnErr: 0 ExchErr: 0 ConnAvg: 0ms LatAvg: 0ms  Msgs: 0
libc++abi.dylib: libc++abi.dylib: terminate called throwing an exceptionterminate called throwing an exceptionlibc++abi.dylib: 
libc++abi.dylib: Abort trap: 6

boost 1.52.0 is installed from homebrew

Also output results are highly variative on my system, (localhost!):

first test ConnAvg: 625.623ms
second test ConnAvg: 0.318ms
third test ConnAvg: 757.165ms
This was true for all implementations I tested (python, perl, node, ruby).
